### PR TITLE
Make fastapi_utils.add_timing_middleware compatible with win32

### DIFF
--- a/fastapi_utils/timing.py
+++ b/fastapi_utils/timing.py
@@ -9,7 +9,11 @@ consider using the coroutine-aware profiling library `yappi`.
 """
 from __future__ import annotations
 
-import resource
+import sys
+
+if sys.platform != "win32":
+    import resource
+
 import time
 from collections.abc import Callable
 from typing import Any

--- a/fastapi_utils/timing.py
+++ b/fastapi_utils/timing.py
@@ -186,6 +186,9 @@ def _get_cpu_time() -> float:
     """
     Generates the cpu time to report. Adds the user and system time, following the implementation from timing-asgi
     """
+    if sys.platform == "win32":
+        return time.process_time()
+
     resources = resource.getrusage(resource.RUSAGE_SELF)
     # add up user time (ru_utime) and system time (ru_stime)
     return resources[0] + resources[1]


### PR DESCRIPTION
Although windows compatibility does not seem to be a priority for the project, these changes make fastapi_utils.add_timing_middleware compatible with win32.
I believe these commits abide by the contributing guidelines, if not, please let me know.

Fixes #144