### PR TITLE
Support Pydantic 2 - is_classvar

### DIFF
--- a/fastapi_utils/cbv.py
+++ b/fastapi_utils/cbv.py
@@ -5,7 +5,6 @@ from collections.abc import Callable
 from typing import Any, TypeVar, get_type_hints, ForwardRef, Type, get_origin, ClassVar, Optional
 
 from fastapi import APIRouter, Depends
-from pydantic.typing import is_classvar
 from starlette.routing import Route, WebSocketRoute
 
 T = TypeVar("T")

--- a/fastapi_utils/cbv.py
+++ b/fastapi_utils/cbv.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Callable
-from typing import Any, TypeVar, get_type_hints
+from typing import Any, TypeVar, get_type_hints, ForwardRef, Type, get_origin, ClassVar, Optional
 
 from fastapi import APIRouter, Depends
 from pydantic.typing import is_classvar
@@ -11,6 +11,25 @@ from starlette.routing import Route, WebSocketRoute
 T = TypeVar("T")
 
 CBV_CLASS_KEY = "__cbv_class__"
+
+
+def _check_classvar(v: Optional[Type[Any]]) -> bool:
+    if v is None:
+        return False
+
+    return v.__class__ == ClassVar.__class__ and getattr(v, '_name', None) == 'ClassVar'
+
+
+def is_classvar(ann_type: Type[Any]) -> bool:
+    if _check_classvar(ann_type) or _check_classvar(get_origin(ann_type)):
+        return True
+
+    # this is an ugly workaround for class vars that contain forward references and are therefore themselves
+    # forward references, see #3679
+    if ann_type.__class__ == ForwardRef and ann_type.__forward_arg__.startswith('ClassVar['):
+        return True
+
+    return False
 
 
 def cbv(router: APIRouter) -> Callable[[type[T]], type[T]]:


### PR DESCRIPTION
Fixes #283 

Only addressing the missing is_classvar in pydantic 2. Added a few methods in cbv.py.

Implemented `is_classvar` and `_check_classvar` using `typing`. 
Note: it's the exact code from pydantic v1 typing.py, so shouldn't break anything

Leaving the rest of the pydantic 2 support to #270 #279  