### PR TITLE
Add support for `Annotated[..., Depends(...)]`

### DIFF
--- a/fastapi_utils/cbv.py
+++ b/fastapi_utils/cbv.py
@@ -74,7 +74,7 @@ def _init_cbv(cls: Type[Any], instance: Any = None) -> None:
     ]
 
     dependency_names: List[str] = []
-    for name, hint in get_type_hints(cls).items():
+    for name, hint in get_type_hints(cls, include_extras=True).items():
         if is_classvar(hint):
             continue
         parameter_kwargs = {"default": getattr(cls, name, Ellipsis)}


### PR DESCRIPTION
Currently, the recommended way to use `Depends` (judging by the [FastAPI docs](https://fastapi.tiangolo.com/tutorial/dependencies)) is with `typing.Annotated`:

> Prefer to use the `Annotated` version if possible.

However, `typing.get_type_hints` strips `Annotated` metadata by default, so you cannot do something like this at the moment:

```python
...

async def provide_storage() -> dict[str, int]:
    return {"A": 1, "B": 2}


StorageDependency = Annotated[dict[str, int], Depends(provide_storage)]


router = APIRouter()

@cbv(router)
class ExampleView:
    storage: StorageDependency

    async def get_value(self, name: str) -> int:
        return self.storage[name]

...
```

Passing `include_extras=True` to `get_type_hints` solves this.